### PR TITLE
Add `Camp.create()` to allow delaying `.listen()`

### DIFF
--- a/lib/camp.js
+++ b/lib/camp.js
@@ -1042,7 +1042,7 @@ function createServerWithSettings (settings) {
   }
 
   server.listenAsConfigured = function() {
-    this.listen(settings.port, settings.hostname);
+    return this.listen(settings.port, settings.hostname);
   }
 
   return server;

--- a/lib/camp.js
+++ b/lib/camp.js
@@ -997,7 +997,7 @@ function createSpdyServer (opts) { return new SpdyCamp(opts); }
 
 var KEY_HEADER = /^-+BEGIN \w+ PRIVATE KEY-+/;
 var CERT_HEADER = /^-+BEGIN CERTIFICATE-+/;
-function startServer (settings) {
+function createServerWithSettings (settings) {
   var server;
   settings.hostname = settings.hostname || '::';
 
@@ -1028,17 +1028,21 @@ function startServer (settings) {
       } catch (e) { log('CA file not found: ' + file, 'error'); }
     });
     if (settings.spdy === false) {
-      server = new SecureCamp(settings).listen(settings.port, settings.hostname);
+      server = new SecureCamp(settings);
     } else {
-      server = new SpdyCamp(settings).listen(settings.port, settings.hostname);
+      server = new SpdyCamp(settings);
     }
   } else { // Nope
-    server = new Camp(settings).listen(settings.port, settings.hostname);
+    server = new Camp(settings);
   }
   if (settings.setuid) {
     server.on('listening', function switchuid() {
       process.setuid(settings.setuid);
     });
+  }
+
+  server.listenAsConfigured = function() {
+    this.listen(settings.port, settings.hostname);
   }
 
   return server;
@@ -1047,7 +1051,7 @@ function startServer (settings) {
 
 // Each camp instance creates an HTTP / HTTPS server automatically.
 //
-function start (settings) {
+function create (settings) {
 
   settings = settings || {};
 
@@ -1061,10 +1065,15 @@ function start (settings) {
 
   settings.port = settings.port || (settings.secure ? 443 : 80);
 
-  return startServer(settings);
+  return createServerWithSettings(settings);
 };
 
+function start (settings) {
+  return create(settings).listenAsConfigured();
+}
 
+
+exports.create = create;
 exports.start = start;
 exports.createServer = createServer;
 exports.createSecureServer = createSecureServer;


### PR DESCRIPTION
In a PaaS environment it's sometimes necessary to fully set up the server before beginning to accept connections. This is possible using e.g. the `createServer()` export, but then you can't use the configuration niceties of `.create()`. This is a quick and dirty fix.