### PR TITLE
add staticMaxAge param

### DIFF
--- a/lib/camp.js
+++ b/lib/camp.js
@@ -359,6 +359,7 @@ function augmentServer(server, opts) {
   server.saveRequestChunks = !!opts.saveRequestChunks;
   server.template = template;
   server.stack = [];
+  server.staticMaxAge = opts.staticMaxAge
   server.stackInsertion = 0;
   defaultRoute.forEach(function(mkfn) { server.handle(mkfn(server)); });
   server.stackInsertion = 0;
@@ -660,6 +661,15 @@ function protectedPath(documentRoot, path) {
   return p.join(documentRoot, p.join('/', path));
 }
 
+function setHeadersForCacheLength(res, cacheLengthSeconds) {
+  const now = new Date();
+  const cacheControl = `max-age=${cacheLengthSeconds}, s-maxage=${cacheLengthSeconds}`;
+  const expires = new Date(now.getTime() + cacheLengthSeconds * 1000).toGMTString();
+
+  res.setHeader('Cache-Control', cacheControl);
+  res.setHeader('Expires', expires);
+}
+
 // End the response `res` with file at path `path`.
 // If the file does not exist, we call `ifNoFile()`.
 function respondWithFile(req, res, path, ifNoFile) {
@@ -673,6 +683,10 @@ function respondWithFile(req, res, path, ifNoFile) {
       realpath = p.join(realpath, 'index.html');
     }
     res.mime(p.extname(realpath).slice(1));
+
+    if (req.server.staticMaxAge) {
+      setHeadersForCacheLength(res, req.server.staticMaxAge);
+    }
 
     // Cache management (compare timestamps at second-level precision).
     var lastModified = Math.floor(stats.mtime / 1000);

--- a/lib/camp.js
+++ b/lib/camp.js
@@ -38,6 +38,8 @@ var binaries = [
       'gif', 'jpg', 'jpeg', 'png', 'svg', 'tiff', 'ico', 'mp4', 'ogv', 'mov',
       'webm', 'wmv'
 ];
+var serverStartTime = new Date();
+var serverStartTimeGMTString = serverStartTime.toGMTString();
 
 
 // Augment IncomingMessage and ServerResponse.
@@ -689,14 +691,13 @@ function respondWithFile(req, res, path, ifNoFile) {
     }
 
     // Cache management (compare timestamps at second-level precision).
-    var lastModified = Math.floor(stats.mtime / 1000);
     var since = req.headers['if-modified-since'];
-    if (since && (lastModified <= Math.floor(new Date(since) / 1000))) {
+    if (since && (Math.floor(serverStartTime / 1000) <= Math.floor(new Date(since) / 1000))) {
       res.statusCode = 304; // not modified.
       res.end();
       return;
     }
-    res.setHeader('Last-Modified', stats.mtime.toUTCString());
+    res.setHeader('Last-Modified', serverStartTimeGMTString);
 
     // Connect the output of the file to the network!
     var raw = fs.createReadStream(realpath);


### PR DESCRIPTION
I've done a couple of different versions of this. This one allows us to set a `staticMaxAge` value, then we use it to set `Cache-Control` and `Expires` in `respondWithFile()`. The downside is this isn't a particuly flexible solution - it just does what we need to set custom `Cache-Control` and `Expires` in the static handler. The advantage of this one is we can calculate the `Expires` header because we work it out inside `respondWithFile()` (although I'm not sure how important that is).

The corresponding code in shields for this one would be like

```js
Camp.create({
  ...
  staticMaxAge: 300,
})
```

I don't really have a strong preference for either approach.