### PR TITLE
add extraHeaders param

### DIFF
--- a/lib/camp.js
+++ b/lib/camp.js
@@ -359,6 +359,7 @@ function augmentServer(server, opts) {
   server.saveRequestChunks = !!opts.saveRequestChunks;
   server.template = template;
   server.stack = [];
+  server.extraHeaders = { ...{ staticLayer: {} }, ...opts.extraHeaders };
   server.stackInsertion = 0;
   defaultRoute.forEach(function(mkfn) { server.handle(mkfn(server)); });
   server.stackInsertion = 0;
@@ -673,6 +674,12 @@ function respondWithFile(req, res, path, ifNoFile) {
       realpath = p.join(realpath, 'index.html');
     }
     res.mime(p.extname(realpath).slice(1));
+
+    Object.entries(req.server.extraHeaders.staticLayer).forEach(
+      function([key, value]) {
+        res.setHeader(key, value);
+      }
+    );
 
     // Cache management (compare timestamps at second-level precision).
     var lastModified = Math.floor(stats.mtime / 1000);


### PR DESCRIPTION
I've done a couple of different versions of this. This one allows us to define some arbitrary custom `extraHeaders`. At the moment I've only implemented `extraHeaders.staticLayer` but in principle we could implement handling of `extraHeaders.routeLayer` `extraHeaders.notFoundLayer` etc if we wanted. This solution gives us more options but because we have to set the headers at init time, we can't set an `Expires` (which we may or may not care about).

The corresponding code in shields for this one would be like

```js
Camp.create({
  ...
  extraHeaders: {
    staticLayer: {
      'Cache-Control': 'max-age=300, s-maxage=300',
    },
  }
})
```

I don't really have a strong preference for either approach.